### PR TITLE
feat: Implement string operations and array bytecode

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -29,6 +29,7 @@ const (
 	OpNull
 	OpGetGlobal
 	OpSetGlobal
+	OpArray
 )
 
 type Definition struct {
@@ -55,6 +56,7 @@ var definitions = map[Opcode]*Definition{
 	OpNull:             {"OpNull", []int{}},
 	OpGetGlobal:        {"OpGetGlobal", []int{2}},
 	OpSetGlobal:        {"OpSetGlobal", []int{2}},
+	OpArray:            {"OpArray", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -203,6 +203,17 @@ func (c *Compiler) Compile(node ast.Node) error {
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))
+	case *ast.ArrayLiteral:
+		numElements := len(node.Elements)
+
+		for _, element := range node.Elements {
+			err := c.Compile(element)
+			if err != nil {
+				return err
+			}
+		}
+
+		c.emit(code.OpArray, numElements)
 
 	case *ast.Boolean:
 		if node.Value {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -196,6 +196,10 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 
+	case *ast.StringLiteral:
+		str := &object.String{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant((str)))
+
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -31,6 +31,16 @@ func New() *Compiler {
 	}
 }
 
+func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
+	compiler := New()
+
+	compiler.constants = constants
+	compiler.symbolTable = s
+
+	return compiler
+
+}
+
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {
 	case *ast.Program:

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -272,6 +272,30 @@ func TestGlobalLetStatements(t *testing.T) {
 	runCompileTests(t, tests)
 }
 
+func TestStringExpressions(t *testing.T) {
+	tests := []compilerTestcase{
+		{
+			input: `"monkey"`,
+			expectedConstants: []interface{}{"monkey"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant,0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `"mon" + "key"`,
+			expectedConstants: []interface{}{"mon","key"},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant,0),
+				code.Make(code.OpConstant,1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+	runCompileTests(t,tests)
+}
+
 func runCompileTests(t *testing.T, tests []compilerTestcase) {
 	t.Helper()
 
@@ -355,6 +379,13 @@ func testConstants(expected []interface{}, actual []object.Object) error {
 			if err != nil {
 				return fmt.Errorf("constant %d - testIntegerObject failed: %s", i, err)
 			}
+		case string:
+			err := testStringObject(constant, actual[i])
+
+			if err != nil {
+				return fmt.Errorf("constant %d - testStringObject failed: %s", i, err)
+			}
+
 		}
 	}
 
@@ -370,6 +401,20 @@ func testIntegerObject(expected int64, actual object.Object) error {
 
 	if result.Value != expected {
 		return fmt.Errorf("Object has wrong value. got=%d, want=%d", result.Value, expected)
+	}
+
+	return nil
+}
+
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+
+	if !ok {
+		return fmt.Errorf("object is not Integer. got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("Object has wrong value. got=%s, want=%s", result.Value, expected)
 	}
 
 	return nil

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -296,6 +296,49 @@ func TestStringExpressions(t *testing.T) {
 	runCompileTests(t,tests)
 }
 
+func TestArrayLiterals(t *testing.T) {
+	tests := []compilerTestcase{
+		{
+			input: "[]",
+			expectedConstants: []interface{}{},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpArray,0),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: "[1, 2, 3]",
+			expectedConstants: []interface{}{1, 2, 3},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpArray,3),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: "[1 + 2, 3 - 4, 5 * 6]",
+			expectedConstants: []interface{}{1, 2, 3, 4, 5, 6},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpConstant, 3),
+				code.Make(code.OpSub),
+				code.Make(code.OpConstant, 4),
+				code.Make(code.OpConstant, 5),
+				code.Make(code.OpMul),
+				code.Make(code.OpArray,3),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompileTests(t,tests)
+}
+
 func runCompileTests(t *testing.T, tests []compilerTestcase) {
 	t.Helper()
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module monkey
 
 go 1.24.0
+
+require github.com/google/go-github v17.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/google/go-github v17.0.0+incompatible h1:N0LgJ1j65A7kfXrZnUDaYCs/Sf4rEjNlfyDHW9dolSY=
+github.com/google/go-github v17.0.0+incompatible/go.mod h1:zLgOLi98H3fifZn+44m+umXrS52loVEgC2AApnigrVQ=

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"monkey/compiler"
 	"monkey/lexer"
+	"monkey/object"
 	"monkey/parser"
 	"monkey/vm"
 )
@@ -14,6 +15,12 @@ const PROMPT = ">> "
 
 func Start(in io.Reader, out io.Writer) {
 	scanner := bufio.NewScanner(in)
+
+	constants := []object.Object{}
+
+	globals := make([]object.Object, vm.GlobalSize)
+
+	symbolTable := compiler.NewSymbolTable()
 
 	for {
 		fmt.Fprintf(out, PROMPT)
@@ -32,7 +39,7 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		comp := compiler.New()
+		comp := compiler.NewWithState(symbolTable, constants)
 		err := comp.Compile(program)
 
 		if err != nil {
@@ -40,7 +47,10 @@ func Start(in io.Reader, out io.Writer) {
 			continue
 		}
 
-		machine := vm.New(comp.Bytecode())
+		code := comp.Bytecode()
+		constants = code.Constants
+
+		machine := vm.NewWithGlobalStore(code, globals)
 
 		err = machine.Run()
 

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -28,6 +28,13 @@ func New(bytecode *compiler.Bytecode) *VM {
 	}
 }
 
+func NewWithGlobalStore(bytecode *compiler.Bytecode, s []object.Object) *VM {
+	vm := New(bytecode)
+	vm.globals = s
+
+	return vm
+}
+
 var True = &object.Boolean{Value: true}
 var False = &object.Boolean{Value: false}
 var Null = &object.Null{}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -156,6 +156,10 @@ func (vm *VM) executeBinaryOperation(op code.Opcode) error {
 		return vm.executeBinaryIntegerOperation(op, left, right)
 	}
 
+	if leftType == object.STRING_OBJ && rightType == object.STRING_OBJ {
+		return vm.executeBinaryStringOperation(op, left, right)
+	}
+
 	return fmt.Errorf("unsupported binary types for binary operation: %s %s", leftType, rightType)
 }
 
@@ -180,6 +184,23 @@ func (vm *VM) executeBinaryIntegerOperation(op code.Opcode, left, right object.O
 
 	return vm.push(&object.Integer{Value: result})
 }
+
+func (vm *VM) executeBinaryStringOperation(op code.Opcode, left, right object.Object) error {
+	leftValue := left.(*object.String).Value
+	rightValue := right.(*object.String).Value
+
+	var result string
+
+	switch op {
+	case code.OpAdd:
+		result = leftValue + rightValue
+	default:
+		return fmt.Errorf("unknown integer operator: %d", op)
+	}
+
+	return vm.push(&object.String{Value: result})
+}
+
 
 func (vm *VM) push(o object.Object) error {
 	if vm.sp >= StackSize {

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -45,6 +45,20 @@ func testBooleanObject(expected bool, actual object.Object) error {
 	return nil
 }
 
+func testStringObject(expected string, actual object.Object) error {
+	result, ok := actual.(*object.String)
+
+	if !ok {
+		return fmt.Errorf("object is not String. got=%T (%+v)", actual, actual)
+	}
+
+	if result.Value != expected {
+		return fmt.Errorf("Object has wrong value. got=%s, want=%s", result.Value, expected)
+	}
+
+	return nil
+}
+
 type vmTestCase struct {
 	input    string
 	expected interface{}
@@ -95,6 +109,11 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 		err := testBooleanObject(bool(expected), actual)
 		if err != nil {
 			t.Errorf("testIntegerObject failed: %s", err)
+		}
+	case string:
+		err := testStringObject(expected, actual)
+		if err != nil {
+			t.Errorf("testStringObject failed: %s", err)
 		}
 	case *object.Null:
 		if actual != Null {
@@ -177,11 +196,22 @@ func TestConditionals(t *testing.T) {
 
 	runVmTests(t, tests)
 }
+
 func TestGlobalLetStatements(t *testing.T) {
 	tests := []vmTestCase{
 		{"let one = 1; one", 1},
 		{"let one = 1; let two = 2; one + two", 3},
 		{"let one = 1; let two = one + one; one + two", 3},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestStringExpressions(t *testing.T) {
+	tests := []vmTestCase{
+		{`"monkey"`, "monkey"},
+		{`"mon" + "key"`, "monkey"},
+		{`"mon" + "key" + "banana"`, "monkeybanana"},
 	}
 
 	runVmTests(t, tests)


### PR DESCRIPTION
This PR implements:

1. String operations in VM including string concatenation
2. Array operations in bytecode (OpArray)
3. Compiler updates for handling string literals and array literals

Changes:
- Added string operation tests in VM
- Added OpArray bytecode instruction
- Updated compiler to handle string and array literals